### PR TITLE
[Refactor] CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
+
+# This file will build McStas and/or McXtrace
+project(mccode C)
+
+option(BUILD_MCSTAS "Build McStas" OFF)
+option(BUILD_MCXTRACE "Build McXtrace" OFF)
+
+if (${BUILD_MCSTAS} AND ${BUILD_MCXTRACE})
+    message(WARNING "Configuration requests building both McStas and McXtrace which is likely to fail.")
+elseif(NOT (${BUILD_MCSTAS} OR ${BUILD_MCXTRACE}))
+    message(FATAL_ERROR "Configuration requires building one of McStas or McXtrace via -DBUILD_MCXTRACE=ON or -DBUILD_MCSTAS=ON")
+endif()
+
+# Set module path
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+
+# Setup McCode values (from mkdist or defaults)
+include(MCUtil)
+
+if(${BUILD_MCSTAS})
+    setupMCCODE("mcstas")
+    message(STATUS "Configuring McStas build ${FLAVOR}")
+    add_subdirectory(mcstas)
+    add_subdirectory(mcstas-comps)
+    add_subdirectory(tools)
+endif()
+
+if (${BUILD_MCXTRACE})
+    setupMCCODE("mcxtrace")
+    message(STATUS "Configuring McXtrace build ${FLAVOR}")
+    add_subdirectory(mcxtrace)
+    add_subdirectory(mcxtrace-comps)
+endif()

--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -9,7 +9,7 @@
 # After doing so (using set()) this module can be included with
 
 macro(AppendDef def)
-    set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND
       PROPERTY COMPILE_DEFINITIONS
       ${def}
       )
@@ -60,11 +60,11 @@ macro(installMCCODE)
   ## Add global definitions
   # set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY COMPILE_DEFINITIONS
   AppendDef(MCCODE_NAME="${MCCODE_NAME}")
-	AppendDef(MCCODE_TARNAME="${MCCODE_TARNAME}")
-	AppendDef(MCCODE_VERSION="${MCCODE_VERSION}")
-	AppendDef(MCCODE_STRING="${MCCODE_STRING}")
-        AppendDef(MCCODE_BUGREPORT="www.${MCCODE_TARNAME}.org")
-	AppendDef(MCCODE_URL="")
+  AppendDef(MCCODE_TARNAME="${MCCODE_TARNAME}")
+  AppendDef(MCCODE_VERSION="${MCCODE_VERSION}")
+  AppendDef(MCCODE_STRING="${MCCODE_STRING}")
+  AppendDef(MCCODE_BUGREPORT="www.${MCCODE_TARNAME}.org")
+  AppendDef(MCCODE_URL="")
 
 	# -DCC_HAS_PROTOS=1
 	# -DSTDC_HEADERS=1
@@ -224,6 +224,7 @@ macro(installMCCODE)
     OUTPUT work/src/lex.yy.c
     COMMAND "${FLEX_EXECUTABLE}" -i "${PROJECT_SOURCE_DIR}/src/instrument.l"
     WORKING_DIRECTORY work/src
+    DEPENDS "${PROJECT_SOURCE_DIR}/src/instrument.l"
   )
 
 
@@ -232,6 +233,7 @@ macro(installMCCODE)
     OUTPUT work/src/instrument.tab.h work/src/instrument.tab.c
     COMMAND "${BISON_EXECUTABLE}" -v -d "${PROJECT_SOURCE_DIR}/src/instrument.y"
     WORKING_DIRECTORY work/src
+    DEPENDS "${PROJECT_SOURCE_DIR}/src/instrument.y" work/src/lex.yy.c
   )
 
   # Handling of system-provided random functions on windows - 
@@ -243,22 +245,22 @@ macro(installMCCODE)
 
   ## Build executable for flavor
   add_executable(
-	  ${FLAVOR}
-	  work/src/cexp.c
-	  work/src/cogen.c
-	  work/src/coords.c
-	  work/src/debug.c
+    ${FLAVOR}
+    work/src/cexp.c
+    work/src/cogen.c
+    work/src/coords.c
+    work/src/debug.c
     work/src/file.c
-	  work/src/list.c
+    work/src/list.c
     work/src/mccode.h
     work/src/memory.c
- 	  work/src/port.c
-	  work/src/port.h
-	  work/src/symtab.c
-	  work/src/re.c
+    work/src/port.c
+    work/src/port.h
+    work/src/symtab.c
+    work/src/re.c
 
     # files generated with flex and bison
- 	  work/src/lex.yy.c
+    work/src/lex.yy.c
     work/src/instrument.tab.h
     work/src/instrument.tab.c
   )

--- a/cmake/Modules/MCUtil.cmake
+++ b/cmake/Modules/MCUtil.cmake
@@ -1,3 +1,5 @@
+cmake_policy(VERSION 3.18.0)
+
 # Install library files into lib/${FLAVOR}, while skipping unneeded files
 macro(installLib path)
   if(WINDOWS)
@@ -20,8 +22,8 @@ endmacro()
 
 # Check whether we are being run through mkdist
 macro(isMkDist outvar)
-  string(REPLACE "@" "_" TMP "@MCCODE_NAME@")
-  string(COMPARE NOTEQUAL "${TMP}" "_MCCODE_NAME_" ${outvar})
+  string(CONFIGURE "@MCCODE_NAME@" TMP @ONLY) # TMP is empty unless MCCODE_NAME is set already
+  string(LENGTH "${TMP}" ${outvar})
 endmacro()
 
 
@@ -57,6 +59,7 @@ macro(setupMCCODE FLAVOR)
 
   # Set macros
   if("${FLAVOR}" STREQUAL "mcstas")
+
     set(NAME             "McStas")
 
     set(FLAVOR           "mcstas")
@@ -93,7 +96,7 @@ macro(setupMCCODE FLAVOR)
     set(MCCODE_YEAR "2100")
   endif()
 
-  set_property(DIRECTORY ${CMAKE_SOURCE_DIR} APPEND PROPERTY COMPILE_DEFINITIONS
+  set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY COMPILE_DEFINITIONS
     NAME="${NAME}" FLAVOR="${FLAVOR}" FLAVOR_UPPER="${FLAVOR_UPPER}"
     FLAVOR_LIB="${FLAVOR_LIB}"
     MCCODE_LIBENV="${MCCODE_LIBENV}" MCCODE_PARTICLE="${MCCODE_PARTICLE}"
@@ -105,11 +108,12 @@ macro(setupMCCODE FLAVOR)
 
   if(MKDIST)
     ## Set mkdist-provided version
-    set(MCCODE_VERSION "@MCCODE_VERSION@")
-    set(MCCODE_NAME "@MCCODE_NAME@")
-    set(MCCODE_DATE "@MCCODE_DATE@")
-    set(MCCODE_STRING "@MCCODE_STRING@")
-    set(MCCODE_TARNAME "@MCCODE_TARNAME@")
+    string(CONFIGURE "@MCCODE_VERSION@" MCCODE_VERSION @ONLY)
+    string(CONFIGURE "@MCCODE_NAME@" MCCODE_NAME @ONLY)
+    string(CONFIGURE "@MCCODE_DATE@" MCCODE_DATE @ONLY)
+    string(CONFIGURE "@MCCODE_STRIN@" MCCODE_STRING @ONLY)
+    string(CONFIGURE "@MCCODE_TARNAME@" MCCODE_TARNAME @ONLY)
+    message(STATUS "Using provided settings MCCODE_VERSION=${MCCODE_VERSION}, MCCODE_NAME=${MCCODE_NAME}, MCCODE_DATE=${MCCODE_DATE}, MCCODE_STRING=${MCCODE_STRING}, MCCODE_TARNAME=${MCCODE_TARNAME}")
   else()
     ## Set Git-specific version
     set(MCCODE_VERSION "2.9999-git")
@@ -197,7 +201,7 @@ macro(setupMCCODE FLAVOR)
   else()
 
     # Have CMake respect install prefix
-    message(${CMAKE_INSTALL_PREFIX})
+    message(STATUS "Install prefix -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
     set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
     set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 

--- a/mcstas-comps/CMakeLists.txt
+++ b/mcstas-comps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 # This will install McStas components
 project(mcstas-comps C Fortran)
@@ -72,7 +72,7 @@ target_link_libraries(mcpl2phits m)
 
 add_executable(
   cif2hkl
-  ${CMAKE_SOURCE_DIR}/libs/cif2hkl/cif2hkl.F90
+  ${CMAKE_CURRENT_SOURCE_DIR}/libs/cif2hkl/cif2hkl.F90
 )
 
 if (NOT WINDOWS)
@@ -104,7 +104,7 @@ if (NOT WINDOWS)
     DESTINATION ${FLAVOR}/${MCCODE_VERSION}/bin
   )
   install (
-    PROGRAMS "${CMAKE_SOURCE_DIR}/libs/mcpl/pymcpltool"
+    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/libs/mcpl/pymcpltool"
     DESTINATION ${FLAVOR}/${MCCODE_VERSION}/bin
   )
 endif()
@@ -115,10 +115,10 @@ foreach(name contrib data examples misc monitors obsolete optics samples share s
 endforeach()
 
 # Include mcstas-comp revision tag file
-configure_file("${CMAKE_SOURCE_DIR}/revision.in" "${WORK}/revision" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/revision.in" "${WORK}/revision" @ONLY)
 
 # copy some descriptory files
-file(COPY "${CMAKE_SOURCE_DIR}/NOMENCLATURE" "${CMAKE_SOURCE_DIR}/README.md" DESTINATION "${WORK}")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/NOMENCLATURE" "${CMAKE_CURRENT_SOURCE_DIR}/README.md" DESTINATION "${WORK}")
 
 if(WINDOWS)
   install(

--- a/mcstas/CMakeLists.txt
+++ b/mcstas/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 # This file will build McStas
 project(mcstas C)
 
 # Set module path
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Setup McCode values (from mkdist or defaults)
 include(MCUtil)

--- a/mcxtrace-comps/CMakeLists.txt
+++ b/mcxtrace-comps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 # This will install McXtrace components
 project(mcxtrace-comps C Fortran)

--- a/mcxtrace/CMakeLists.txt
+++ b/mcxtrace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 ## This file will build McXtrace
 project(mcxtrace C)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
+
+add_subdirectory(Legacy-Perl-cmdline)
+add_subdirectory(Python)

--- a/tools/Legacy-Perl-cmdline/CMakeLists.txt
+++ b/tools/Legacy-Perl-cmdline/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(legacy-tools-cmdline C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
@@ -22,7 +25,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 

--- a/tools/Legacy-Perl/CMakeLists.txt
+++ b/tools/Legacy-Perl/CMakeLists.txt
@@ -24,7 +24,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 

--- a/tools/Python/CMakeLists.txt
+++ b/tools/Python/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
+
+
+add_subdirectory(mccodelib)
+add_subdirectory(mcdisplay)
+add_subdirectory(mcdoc)
+add_subdirectory(mcgui)
+add_subdirectory(mcplot)
+add_subdirectory(mcresplot)
+add_subdirectory(mcrun)
+#add_subdirectory(mctest)

--- a/tools/Python/mccodelib/CMakeLists.txt
+++ b/tools/Python/mccodelib/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mccodelib C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -22,7 +25,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 # Select prefix
@@ -92,8 +94,8 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure config file
-configure_file("${CMAKE_SOURCE_DIR}/mccode_config.py.in" "${WORK}/mccode_config.py" @ONLY)
-configure_file("${CMAKE_SOURCE_DIR}/mccode_config.json.in" "${WORK}/mccode_config.json" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccode_config.py.in" "${WORK}/mccode_config.py" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccode_config.json.in" "${WORK}/mccode_config.json" @ONLY)
 set(BINS "${WORK}/mccode_config.py" "${WORK}/mccode_config.json")
 
 if(WINDOWS)

--- a/tools/Python/mcdisplay/CMakeLists.txt
+++ b/tools/Python/mcdisplay/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
+
+
+add_subdirectory(matplotlib)
+add_subdirectory(pyqtgraph)
+add_subdirectory(webgl)

--- a/tools/Python/mcdisplay/matplotlib/CMakeLists.txt
+++ b/tools/Python/mcdisplay/matplotlib/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcdisplay C)
@@ -8,7 +9,7 @@ option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +25,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 
@@ -76,10 +76,10 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display" @ONLY)
 
 # Configure internal naming and how we call mcrun/mxrun across systems
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.py" "${CMAKE_SOURCE_DIR}/${P}display.py" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.py" "${CMAKE_CURRENT_SOURCE_DIR}/${P}display.py" @ONLY)
 
 if(WINDOWS)
   set(BINS "${PROJECT_SOURCE_DIR}/mcdisplay.py")

--- a/tools/Python/mcdisplay/pyqtgraph/CMakeLists.txt
+++ b/tools/Python/mcdisplay/pyqtgraph/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcdisplay-pyqtgraph C)
@@ -8,7 +9,7 @@ option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +25,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 
@@ -84,7 +84,7 @@ include(CPack)
 
 set(WORK "${PROJECT_BINARY_DIR}/work")
 
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-pyqtgraph-py" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-pyqtgraph-py" @ONLY)
 
 # Program files
 if(WINDOWS)

--- a/tools/Python/mcdisplay/webgl/CMakeLists.txt
+++ b/tools/Python/mcdisplay/webgl/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcdisplay-webgl C)
@@ -8,7 +9,7 @@ option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +25,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 
@@ -84,9 +84,9 @@ include(CPack)
 
 set(WORK "${PROJECT_BINARY_DIR}/work")
 
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-webgl" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-webgl" @ONLY)
 
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-webgl-py" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display-webgl-py" @ONLY)
 
 # Program files
 if(WINDOWS)

--- a/tools/Python/mcdoc/CMakeLists.txt
+++ b/tools/Python/mcdoc/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcdoc C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 # Select prefix
@@ -78,7 +80,7 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcdoc.in" "${WORK}/${P}doc" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdoc.in" "${WORK}/${P}doc" @ONLY)
 
 
 if(WINDOWS)
@@ -119,9 +121,7 @@ if(NOT WINDOWS)
     "${TOOLS_LIB}/mcdoc" "${WORK}/${P}doc"
     )
 
-  add_custom_target(
-    "CREATE_SYMLINK" ALL DEPENDS "${WORK}/${P}doc"
-    )
+  add_custom_target("CREATE_${PROJECT_NAME}_SYMLINK"  ALL DEPENDS "${WORK}/${P}doc")
 
   install(
     PROGRAMS "${WORK}/${P}doc"

--- a/tools/Python/mcgui/CMakeLists.txt
+++ b/tools/Python/mcgui/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcgui C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 # Select prefix
@@ -88,10 +90,10 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcgui.in" "${WORK}/${P}gui" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcgui.in" "${WORK}/${P}gui" @ONLY)
 
 # Configure launcher
-configure_file("${CMAKE_SOURCE_DIR}/McCode-py.desktop.in" work/@NAME@-@MCCODE_VERSION@-py.desktop @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/McCode-py.desktop.in" "work/${NAME}-${MCCODE_VERSION}-py.desktop")
 
 if(WINDOWS)
   set(BINS "${PROJECT_SOURCE_DIR}/mcgui.py")
@@ -137,7 +139,7 @@ if(NOT WINDOWS)
   )
 
   add_custom_target(
-    "CREATE_SYMLINK" ALL DEPENDS "${WORK}/${P}gui"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}gui"
     )
 
   install(
@@ -147,7 +149,7 @@ if(NOT WINDOWS)
     )
 
   install(
-    FILES "${WORK}/@NAME@-@MCCODE_VERSION@-py.desktop" "@FLAVOR@-py.png"
+    FILES "${WORK}/${NAME}-${MCCODE_VERSION}-py.desktop" "${FLAVOR}-py.png"
     DESTINATION "${FLAVOR}/${MCCODE_VERSION}/launchers/"
   )
 

--- a/tools/Python/mcplot/CMakeLists.txt
+++ b/tools/Python/mcplot/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
+
+add_subdirectory(matplotlib)
+add_subdirectory(pyqtgraph)
+add_subdirectory(svg)

--- a/tools/Python/mcplot/matplotlib/CMakeLists.txt
+++ b/tools/Python/mcplot/matplotlib/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcplot C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 # Select prefix
@@ -88,7 +90,7 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-matplotlib" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-matplotlib" @ONLY)
 
 
 if(WINDOWS)

--- a/tools/Python/mcplot/pyqtgraph/CMakeLists.txt
+++ b/tools/Python/mcplot/pyqtgraph/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcplot-pyqtgraph C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 
@@ -85,7 +87,7 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-pyqtgraph" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-pyqtgraph" @ONLY)
 
 # Program files
 if(WINDOWS)

--- a/tools/Python/mcplot/svg/CMakeLists.txt
+++ b/tools/Python/mcplot/svg/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas components
 project(python-tools-mcplot-svg C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 
@@ -86,7 +88,7 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-svg" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcplot.in" "${WORK}/${P}plot-svg" @ONLY)
 
 # Program files
 if(WINDOWS)

--- a/tools/Python/mcresplot/CMakeLists.txt
+++ b/tools/Python/mcresplot/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas mcresplot
 project(python-tools-mcresplot)
 
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
+
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -65,7 +68,7 @@ else()
 endif()
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcresplot.in" "${WORK}/mcresplot" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcresplot.in" "${WORK}/mcresplot" @ONLY)
 
 if(WINDOWS)
   install(
@@ -94,7 +97,7 @@ if(NOT WINDOWS)
   endforeach()
   
   add_custom_target(
-    "CREATE_SYMLINK" ALL DEPENDS "${WORK}/mcresplot"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/mcresplot"
     )
 
   install(

--- a/tools/Python/mcrun/CMakeLists.txt
+++ b/tools/Python/mcrun/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.18.0)
+cmake_policy(VERSION 3.18.0)
 
 # This will install McStas or McXtrace mc/mxrun
 project(python-tools-mcrun C)
+
+message(STATUS "Configure ${CMAKE_PROJECT_NAME} ${FLAVOR} ${PROJECT_NAME}")
 
 # Choose between McStas or McXtrace
 option(enable_mcstas   "Choose the McStas flavor" off)
 option(enable_mcxtrace "Choose the McXtrace flavor (trumps enable_mcstas)" Off)
 
 # Set module path
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 # Set McCode values (from mkdist or defaults)
 include(MCUtil)
@@ -24,7 +27,6 @@ else()
     "Please use either -Denable_mcstas=1 or -Denable_mcxtrace=1")
 endif()
 
-message("Enabling ${FLAVOR} flavor")
 setupMCCODE("${FLAVOR}")
 
 # Select prefix
@@ -78,7 +80,7 @@ else()
 endif()
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcrun.in" "${WORK}/${P}run" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcrun.in" "${WORK}/${P}run" @ONLY)
 
 if(WINDOWS)
   install(
@@ -108,7 +110,7 @@ if(NOT WINDOWS)
   endforeach()
   
   add_custom_target(
-    "CREATE_SYMLINK" ALL DEPENDS "${WORK}/${P}run"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}run"
     )
 
   install(


### PR DESCRIPTION
## Rational
Building McCode-3 projects using CMake requires the use of one or more custom shell scripts to set variables, configure and build dependencies, and run the interface with CMake. This build system is not welcoming to new developers and foregoes most of the cross-platform compatibility provided by the Kitware CMake tools.

## Changes (thus far)
The existing build system has been overlaid with a new CMake hierarchy that understands (some of) the build complexities. The top level CMakeLists.txt file is used to select a McStas or McXtrace build as, at present, the two have conflicting CMake parameters. Lower-level CMakeLists.txt files have been modified to make use of the CMAKE_CURRENT_*_DIR variables to allow for the same relative file location commands as were used before. New CMakeList.txt files have been added in tools/, tools/Python, tools/Python/mcdisplay/, and tools/Python/mcplot which allow for all sub-folder projects to be collected by the top-level configuration. Additionally, the old-style automatic macro expansion has been removed from the CMake files. And custom target dependencies have been included.

## Limitations
The new CMakeLists.txt file is only suitable for local machine development. More work would be needed to move the whole packaging into the new CMake structure.